### PR TITLE
fix: allow search to work if name is not lowercase

### DIFF
--- a/src/PokeAPI.jsx
+++ b/src/PokeAPI.jsx
@@ -12,8 +12,8 @@ export default function PokeAPI() {
     async function getData() {
 
       try {
-
-        let res = await axios.get(`https://pokeapi.co/api/v2/pokemon/${Find}`);
+        let searchQuery = Find.toLowerCase();
+        let res = await axios.get(`https://pokeapi.co/api/v2/pokemon/${searchQuery}`);
         setImg(res.data.sprites.front_default);
         setType(res.data.types[0].type.name);
         setdisName(Find);


### PR DESCRIPTION
Eg currently if you search "Pichu" it will say doesnt exists, but with this fix if you search "Pichu" it will work.